### PR TITLE
Fixes the library when used with CJS or AMD loaders.

### DIFF
--- a/lib/wrapple.js
+++ b/lib/wrapple.js
@@ -1,12 +1,14 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
-        define([], factory);
+        define(function () {
+            return factory(root);
+        });
     } else if (typeof exports === 'object') {
-        module.exports = factory();
+        module.exports = factory(root);
     } else {
         root.wrapple = factory(root);
     }
-}(this, function (root) {
+}(self, function (root) {
 
     var names = [];
     function wrap(name) {


### PR DESCRIPTION
I haven't added tests yet, since it's not clear how they should be added. I'd be happy to write a set of tests that run in node and use `eval` (actually `new Function`) if that works for you.

The move from `this` to `self` is so that the CJS wrapper won't just pick up an empty `module.exports`. It should still work in other environments and workers (but not Node).
