### PR TITLE
Support Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ wrapple uses a couple of methods from ES5.1
 
 If you need to support old browsers, you should ensure that these have been polyfilled.
 
+### Node.js supported
+
+`wrapple` can work in Node.js environments just like in browser environments.
+
 ## Usage
 
 Access browser natives through wrapple

--- a/lib/wrapple.js
+++ b/lib/wrapple.js
@@ -8,7 +8,7 @@
     } else {
         root.wrapple = factory(root);
     }
-}(self, function (root) {
+}(typeof self !== 'undefined' ? self : global, function (root) {
 
     var names = [];
     function wrap(name) {


### PR DESCRIPTION
Hello.

I think `wrapple` is very cool library.
I want to use wrapple in Node because Node also has readonly property such as `process.platform`.

But, `wrapple` does not work in Node...

```
        Warning: /home/pine/project/dotfiles/node_modules/wrapple/lib/wrapple.js:11
    }(self, function (root) {
      ^

    ReferenceError: self is not defined
```

I've fixed it :smile:
 Would you support Node ?
